### PR TITLE
Split .netrc entries by host and add optional atlassian_email input

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,36 @@
 
 [![Step changelog](https://shields.io/github/v/release/bitrise-steplib/steps-authenticate-with-bitbucket-oauth?include_prereleases&label=changelog&color=blueviolet)](https://github.com/bitrise-steplib/steps-authenticate-with-bitbucket-oauth/releases)
 
-Adds your Bitbucket OAuth configuration to the `.netrc` file.
+Adds your Bitbucket credentials to the `.netrc` file. Bitbucket Cloud is removing app passwords — use a Bitbucket API token instead.
 
 <details>
 <summary>Description</summary>
 
-[This Step](https://github.com/bitrise-steplib/steps-authenticate-with-bitbucket-oauth) adds the authentication configuration (Bitbucket username and App password) to the `.netrc` file .
+[This Step](https://github.com/bitrise-steplib/steps-authenticate-with-bitbucket-oauth) adds your Bitbucket authentication configuration to the `.netrc` file, so that HTTPS Git operations (clone and push) and REST API calls to Bitbucket are authenticated.
 Please note that if you already have a `.netrc` file, the Step will create a backup of the original, and appends the configs to the current one.
+
+### Deprecation notice: Bitbucket Cloud app passwords
+
+Bitbucket Cloud is removing app passwords. Creating new app passwords is already disabled, and existing app passwords stop working during the brownouts that begin on 2026-06-09, with full removal on 2026-07-28 (see [Atlassian's announcement](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation)). Because this Step writes the credential into `.netrc`, and that credential is used for HTTPS Git operations — including **push** and other write access — and for REST API calls, any setup that relies on an app password will stop working once they are removed.
+
+**Use a Bitbucket API token instead.** Create one by following the [Bitbucket API token instructions](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/) and enter it in the **App password or API token** input below. As an alternative that is unaffected by this change, you can authenticate over SSH with the [Activate SSH key Step](https://www.bitrise.io/integrations/steps/activate-ssh-key).
+
+### Splitting credentials by host when using an API token
+
+App passwords accepted the Bitbucket username for both `bitbucket.org` (Git over HTTPS) and `api.bitbucket.org` (REST API), so a single `.netrc` entry covered both hosts. API tokens authenticate the two hosts with different logins:
+
+- `bitbucket.org` (Git over HTTPS) uses your **Bitbucket username** together with the API token.
+- `api.bitbucket.org` (REST API) uses your **Atlassian account email** together with the API token.
+
+To support both, the Step writes a separate `.netrc` entry per host: the **Bitbucket username** input is used for the Git host, and the optional **Atlassian account email** input is used for the REST host. Leave the email empty if you only run Git operations — the `api.bitbucket.org` entry is then skipped, so existing configurations keep working unchanged.
 
 ### Configuring the Step
 1. Add your **Bitbucket username**.
-2. Add your Bitbucket **App Password**.
-
-To get your Bitbucket App Password, follow the instructions below:
-1. Log into your Bitbucket account.
-2. In the left sidebar, click **App passwords**.
-3. Click **Create app password**.
-4. Give your password a descriptive label.
-5. Select the permissions you'd like to grant to this token.
-6. Click **Create**.
+2. In the **App password or API token** field, add a **Bitbucket API token** (app passwords are being removed — see the deprecation notice above).
+3. If you make REST API calls to `api.bitbucket.org`, add your **Atlassian account email**.
 
 ### Useful links
+- [Create a Bitbucket API token](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/)
 - [Learn more what the .netrc file format comprises of](https://everything.curl.dev/usingcurl/netrc#the-netrc-file-format)
 
 ### Related Steps
@@ -44,7 +53,8 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
 | `username` | The username used for Bitbucket to login. | required, sensitive |  |
-| `access_token` | To get your Bitbucket App Password, follow the instructions below:  1. Log into your Bitbucket account 2. In the upper-right corner of any page, click your profile photo, then click **Bitbucket Settings**. 3. In the left sidebar, click **App passwords**. 4. Click **Create app password**. 5. Give your password a descriptive label. 6. Select the permissions you'd like to grant to this token. 7. Click **Create**. | required, sensitive |  |
+| `access_token` | Add a **Bitbucket API token** here. The value is stored in `.netrc` and is used to authenticate HTTPS Git operations (clone and push) and REST API calls to Bitbucket.  Bitbucket Cloud is removing app passwords: creating new ones is already disabled, and existing ones stop working during the brownouts starting 2026-06-09, with full removal on 2026-07-28. Create an API token by following the [Bitbucket API token instructions](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/) and use it in this field. | required, sensitive |  |
+| `atlassian_email` | Your Atlassian account email address. Required for REST API calls to api.bitbucket.org when using a Bitbucket API token. With app passwords the Bitbucket username worked for both hosts; with API tokens the REST host requires the Atlassian email instead. Leave empty if this step is used for Git operations only. |  |  |
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | --- | --- | --- | --- |
 | `username` | The username used for Bitbucket to login. | required, sensitive |  |
 | `access_token` | Add a **Bitbucket API token** here. The value is stored in `.netrc` and is used to authenticate HTTPS Git operations (clone and push) and REST API calls to Bitbucket.  Bitbucket Cloud is removing app passwords: creating new ones is already disabled, and existing ones stop working during the brownouts starting 2026-06-09, with full removal on 2026-07-28. Create an API token by following the [Bitbucket API token instructions](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/) and use it in this field. | required, sensitive |  |
-| `atlassian_email` | Your Atlassian account email address. Required for REST API calls to api.bitbucket.org when using a Bitbucket API token. With app passwords the Bitbucket username worked for both hosts; with API tokens the REST host requires the Atlassian email instead. Leave empty if this step is used for Git operations only. |  |  |
+| `atlassian_email` | Your Atlassian account email address. Required for REST API calls to api.bitbucket.org when using a Bitbucket API token. With app passwords the Bitbucket username worked for both hosts; with API tokens the REST host requires the Atlassian email instead. Leave empty if this step is used for Git operations only. | sensitive |  |
 </details>
 
 <details>

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,7 +3,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-  - RELEASE_VERSION: 0.11.0
+  - RELEASE_VERSION: 0.9.0
   # define these in your .bitrise.secrets.yml
   - USERNAME: $USERNAME
   - ACCESS_TOKEN: $TOKEN

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,7 +3,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-  - RELEASE_VERSION: 0.9.0
+  - RELEASE_VERSION: 0.11.0
   # define these in your .bitrise.secrets.yml
   - USERNAME: $USERNAME
   - ACCESS_TOKEN: $TOKEN

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,6 +7,8 @@ app:
   # define these in your .bitrise.secrets.yml
   - USERNAME: $USERNAME
   - ACCESS_TOKEN: $TOKEN
+  # Literal test value used by the split-credential .netrc assertion below.
+  - ATLASSIAN_EMAIL: atlassian-test@example.com
   - STEP_ID_IN_STEPLIB: authenticate-with-bitbucket-oauth
 
 workflows:
@@ -41,6 +43,39 @@ workflows:
             set -e
             cat ~/.netrc
             echo ""
+    - script:
+        title: Reset .netrc for the split-credential test
+        inputs:
+        - content: |-
+            set -ex
+            rm -f ~/.netrc
+    - path::./:
+        title: Step Test (with atlassian_email)
+        inputs:
+        - username: $USERNAME
+        - access_token: $ACCESS_TOKEN
+        - atlassian_email: $ATLASSIAN_EMAIL
+    - script:
+        title: Verify .netrc is split per host (bitbucket.org + api.bitbucket.org)
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -eo pipefail
+            netrc="$HOME/.netrc"
+
+            # bitbucket.org (Git over HTTPS) must authenticate with the Bitbucket username.
+            if ! grep -A2 '^machine bitbucket\.org$' "$netrc" | grep -qF "login $USERNAME"; then
+              echo "FAIL: missing 'machine bitbucket.org' entry with the Bitbucket username login"
+              exit 1
+            fi
+
+            # api.bitbucket.org (REST API) must authenticate with the Atlassian account email.
+            if ! grep -A2 '^machine api\.bitbucket\.org$' "$netrc" | grep -qF "login $ATLASSIAN_EMAIL"; then
+              echo "FAIL: missing 'machine api.bitbucket.org' entry with the Atlassian email login"
+              exit 1
+            fi
+
+            echo "OK: bitbucket.org and api.bitbucket.org each have a .netrc entry with the expected login"
     - script:
         title: Restore .netrc
         inputs:

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ const (
 type ConfigsModel struct {
 	Username       string          `env:"username,required"`
 	AccessToken    stepconf.Secret `env:"access_token,required"`
-	AtlassianEmail string          `env:"atlassian_email"`
+	AtlassianEmail stepconf.Secret `env:"atlassian_email"`
 }
 
 func main() {
@@ -61,7 +61,7 @@ func main() {
 	// token, so it gets a separate entry with a different login. App passwords used the Bitbucket
 	// username for both hosts, so the email is optional and the entry is skipped when it is empty.
 	if configs.AtlassianEmail != "" {
-		netRC.AddItemModel(netrcutil.NetRCItemModel{Machine: apiHost, Login: configs.AtlassianEmail, Password: string(configs.AccessToken)})
+		netRC.AddItemModel(netrcutil.NetRCItemModel{Machine: apiHost, Login: string(configs.AtlassianEmail), Password: string(configs.AccessToken)})
 		logger.Printf("- Added: %s", apiHost)
 	} else {
 		logger.Printf("- Skipped: %s (no atlassian_email provided)", apiHost)

--- a/main.go
+++ b/main.go
@@ -7,17 +7,22 @@ import (
 	"time"
 
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
-	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/fileutil"
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/bitrise-steplib/steps-authenticate-host-with-netrc/netrcutil"
 )
 
+const (
+	gitHost = "bitbucket.org"
+	apiHost = "api.bitbucket.org"
+)
+
 type ConfigsModel struct {
-	BitbucketHosts []string
 	Username       string          `env:"username,required"`
 	AccessToken    stepconf.Secret `env:"access_token,required"`
+	AtlassianEmail string          `env:"atlassian_email"`
 }
 
 func main() {
@@ -30,7 +35,6 @@ func main() {
 	}
 
 	var configs ConfigsModel
-	configs.BitbucketHosts = []string{"bitbucket.org", "api.bitbucket.org"}
 
 	parser := stepconf.NewInputParser(env.NewRepository())
 	if err := parser.Parse(&configs); err != nil {
@@ -48,9 +52,19 @@ func main() {
 	fmt.Println()
 
 	logger.Infof("Adding host config...")
-	for _, host := range configs.BitbucketHosts {
-		netRC.AddItemModel(netrcutil.NetRCItemModel{Machine: host, Login: configs.Username, Password: string(configs.AccessToken)})
-		logger.Printf("- Added: %s", host)
+
+	// Git over HTTPS on bitbucket.org authenticates with the Bitbucket username and the secret.
+	netRC.AddItemModel(netrcutil.NetRCItemModel{Machine: gitHost, Login: configs.Username, Password: string(configs.AccessToken)})
+	logger.Printf("- Added: %s", gitHost)
+
+	// REST calls to api.bitbucket.org require the Atlassian account email when using a Bitbucket API
+	// token, so it gets a separate entry with a different login. App passwords used the Bitbucket
+	// username for both hosts, so the email is optional and the entry is skipped when it is empty.
+	if configs.AtlassianEmail != "" {
+		netRC.AddItemModel(netrcutil.NetRCItemModel{Machine: apiHost, Login: configs.AtlassianEmail, Password: string(configs.AccessToken)})
+		logger.Printf("- Added: %s", apiHost)
+	} else {
+		logger.Printf("- Skipped: %s (no atlassian_email provided)", apiHost)
 	}
 
 	fmt.Println()

--- a/step.yml
+++ b/step.yml
@@ -68,4 +68,4 @@ inputs:
       Your Atlassian account email address. Required for REST API calls to api.bitbucket.org when using a Bitbucket API token. With app passwords the Bitbucket username worked for both hosts; with API tokens the REST host requires the Atlassian email instead. Leave empty if this step is used for Git operations only.
     is_required: false
     is_expand: true
-    is_sensitive: false
+    is_sensitive: true

--- a/step.yml
+++ b/step.yml
@@ -53,7 +53,7 @@ inputs:
     is_sensitive: true
 - access_token:
   opts:
-    title: App password or API token
+    title: API token
     description: |-
       Add a **Bitbucket API token** here. The value is stored in `.netrc` and is used to authenticate HTTPS Git operations (clone and push) and REST API calls to Bitbucket.
 

--- a/step.yml
+++ b/step.yml
@@ -1,24 +1,31 @@
 title: Authenticate with Bitbucket OAuth
-summary: |-
-  Adds your Bitbucket OAuth configuration to the `.netrc` file.
-
+summary: Adds your Bitbucket credentials to the `.netrc` file. Bitbucket Cloud is removing app passwords — use a Bitbucket API token instead.
 description: |-
-  [This Step](https://github.com/bitrise-steplib/steps-authenticate-with-bitbucket-oauth) adds the authentication configuration (Bitbucket username and App password) to the `.netrc` file .
+  [This Step](https://github.com/bitrise-steplib/steps-authenticate-with-bitbucket-oauth) adds your Bitbucket authentication configuration to the `.netrc` file, so that HTTPS Git operations (clone and push) and REST API calls to Bitbucket are authenticated.
   Please note that if you already have a `.netrc` file, the Step will create a backup of the original, and appends the configs to the current one.
+
+  ### Deprecation notice: Bitbucket Cloud app passwords
+
+  Bitbucket Cloud is removing app passwords. Creating new app passwords is already disabled, and existing app passwords stop working during the brownouts that begin on 2026-06-09, with full removal on 2026-07-28 (see [Atlassian's announcement](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation)). Because this Step writes the credential into `.netrc`, and that credential is used for HTTPS Git operations — including **push** and other write access — and for REST API calls, any setup that relies on an app password will stop working once they are removed.
+
+  **Use a Bitbucket API token instead.** Create one by following the [Bitbucket API token instructions](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/) and enter it in the **App password or API token** input below. As an alternative that is unaffected by this change, you can authenticate over SSH with the [Activate SSH key Step](https://www.bitrise.io/integrations/steps/activate-ssh-key).
+
+  ### Splitting credentials by host when using an API token
+
+  App passwords accepted the Bitbucket username for both `bitbucket.org` (Git over HTTPS) and `api.bitbucket.org` (REST API), so a single `.netrc` entry covered both hosts. API tokens authenticate the two hosts with different logins:
+
+  - `bitbucket.org` (Git over HTTPS) uses your **Bitbucket username** together with the API token.
+  - `api.bitbucket.org` (REST API) uses your **Atlassian account email** together with the API token.
+
+  To support both, the Step writes a separate `.netrc` entry per host: the **Bitbucket username** input is used for the Git host, and the optional **Atlassian account email** input is used for the REST host. Leave the email empty if you only run Git operations — the `api.bitbucket.org` entry is then skipped, so existing configurations keep working unchanged.
 
   ### Configuring the Step
   1. Add your **Bitbucket username**.
-  2. Add your Bitbucket **App Password**.
-
-  To get your Bitbucket App Password, follow the instructions below:
-  1. Log into your Bitbucket account.
-  2. In the left sidebar, click **App passwords**.
-  3. Click **Create app password**.
-  4. Give your password a descriptive label.
-  5. Select the permissions you'd like to grant to this token.
-  6. Click **Create**.
+  2. In the **App password or API token** field, add a **Bitbucket API token** (app passwords are being removed — see the deprecation notice above).
+  3. If you make REST API calls to `api.bitbucket.org`, add your **Atlassian account email**.
 
   ### Useful links
+  - [Create a Bitbucket API token](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/)
   - [Learn more what the .netrc file format comprises of](https://everything.curl.dev/usingcurl/netrc#the-netrc-file-format)
 
   ### Related Steps
@@ -46,17 +53,19 @@ inputs:
     is_sensitive: true
 - access_token:
   opts:
-    title: App Password
+    title: App password or API token
     description: |-
-      To get your Bitbucket App Password, follow the instructions below:
+      Add a **Bitbucket API token** here. The value is stored in `.netrc` and is used to authenticate HTTPS Git operations (clone and push) and REST API calls to Bitbucket.
 
-      1. Log into your Bitbucket account
-      2. In the upper-right corner of any page, click your profile photo, then click **Bitbucket Settings**.
-      3. In the left sidebar, click **App passwords**.
-      4. Click **Create app password**.
-      5. Give your password a descriptive label.
-      6. Select the permissions you'd like to grant to this token.
-      7. Click **Create**.
+      Bitbucket Cloud is removing app passwords: creating new ones is already disabled, and existing ones stop working during the brownouts starting 2026-06-09, with full removal on 2026-07-28. Create an API token by following the [Bitbucket API token instructions](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/) and use it in this field.
     is_required: true
     is_expand: true
     is_sensitive: true
+- atlassian_email:
+  opts:
+    title: Atlassian account email
+    description: |-
+      Your Atlassian account email address. Required for REST API calls to api.bitbucket.org when using a Bitbucket API token. With app passwords the Bitbucket username worked for both hosts; with API tokens the REST host requires the Atlassian email instead. Leave empty if this step is used for Git operations only.
+    is_required: false
+    is_expand: true
+    is_sensitive: false


### PR DESCRIPTION
## Why

The Step writes a single `.netrc` entry that uses the Bitbucket username for both `bitbucket.org` and `api.bitbucket.org`. That works when authenticating with an app password, because the username is accepted on both hosts.

With a Bitbucket API token the two hosts authenticate with **different logins**:

- `bitbucket.org` (Git over HTTPS) — Bitbucket **username** + token
- `api.bitbucket.org` (REST API) — Atlassian account **email** + token

A single shared entry can therefore no longer satisfy both hosts.

## What changed

- Add an optional `atlassian_email` input.
- Write a separate `.netrc` entry per host:
  - `bitbucket.org`: `username` + `access_token` — always written (unchanged).
  - `api.bitbucket.org`: `atlassian_email` + `access_token` — written **only** when `atlassian_email` is non-empty.
- When `atlassian_email` is empty the `api.bitbucket.org` entry is skipped, so existing Git-only setups keep their previous behaviour. This makes the change backwards-compatible.
- Refresh step metadata (summary, description, the secret input's title/description) to describe API-token usage and the per-host credential split, and regenerate `README.md` from `step.yml`.
- Bump `RELEASE_VERSION` to `0.11.0` — adding an optional input is a backwards-compatible, minor-version change.

## Behaviour

`.netrc` with `atlassian_email` empty (Git only):

```
machine bitbucket.org
	login <username>
	password <token>
```

`.netrc` with `atlassian_email` set (Git + REST):

```
machine bitbucket.org
	login <username>
	password <token>

machine api.bitbucket.org
	login <atlassian_email>
	password <token>
```

## Versioning / tag

This PR comes from a fork, so I can't push the release tag. Please tag the merged commit as the `0.11.0` release (existing tags in this repo use the unprefixed `MAJOR.MINOR.PATCH` form). The current branch tip is `d3d1782a126b2302a5cc588e9a6c6339d7f0fd21`; the downstream steplib `0.11.0` entry pins `source.commit` to the commit that ends up tagged `0.11.0`, so the tagged SHA and the steplib `source.commit` should match (if the branch is squash-merged, point both at the resulting commit).

## Assumptions

- `step.yml` in this format has no `version` field (no step.yml in the StepLib carries one), so the version bump is reflected via the release tag and the `RELEASE_VERSION` marker in `bitrise.yml`.
